### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     Rcpp (>= 1.0.5),
     methods
 Imports:
-    rstan (>= 2.21.0),
+    rstan (>= 2.26.0),
     rstantools (>= 2.3.0),
     RcppParallel (>= 5.0.1),
     dplyr (>= 0.7.8),
@@ -32,8 +32,8 @@ LinkingTo:
     Rcpp,
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.21.0),
-    StanHeaders (>= 2.21.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Encoding: UTF-8
 LazyData: true
 Repository: CRAN

--- a/inst/stan/SimulationFunctions.stan
+++ b/inst/stan/SimulationFunctions.stan
@@ -22,7 +22,7 @@ vector DrawMlhs_rng(int nerrs, int draw_mlhs){
 	if(draw_mlhs == 0){
 		error = to_vector(uniform_rng(temp0, 1));
 	} else if(draw_mlhs == 1){
-		int temp1[nerrs];
+		array[nerrs] int temp1;
 		vector[nerrs] temp;
 
 		for (err in 1:nerrs)
@@ -34,11 +34,11 @@ vector DrawMlhs_rng(int nerrs, int draw_mlhs){
 return(error);
 }
 
-vector[] DrawError_rng(real quant_num, vector quant_j, vector price_j,
+array[] vector DrawError_rng(real quant_num, vector quant_j, vector price_j,
 					vector psi_j, vector phi_j, vector gamma_j, vector alpha, real scale,
 					int model_num, int nalts, int nerrs, int cond_error, int draw_mlhs){
 
-	vector[nalts+1] out[nerrs];
+	array[nerrs] vector[nalts+1] out;
 	matrix[nerrs, nalts+1] error;
 
 	if (cond_error == 0){	// Unconditional
@@ -75,11 +75,11 @@ return(out);
  * Returns an ranking vector of non-numeraire alts by MUzero
  * @return integer vector of ordered alts by MUzero
  */
-int[] CalcAltOrder(vector MUzero, int nalts) {
+array[] int CalcAltOrder(vector MUzero, int nalts) {
 
-	int order_x[nalts+1];
+	array[nalts+1] int order_x;
 	vector[nalts] ord_alts;
-	int order_MU[nalts] = sort_indices_desc(MUzero[2:nalts+1]);
+	array[nalts] int order_MU = sort_indices_desc(MUzero[2:nalts+1]);
 
 	for (j in 1:nalts)
 		ord_alts[j] = j;
@@ -98,7 +98,7 @@ matrix SortParmMatrix(vector MUzero, vector price, vector gamma, vector alpha_ph
 	vector[nalts] price_j = price[2:nalts+1];
 	vector[nalts] gamma_j = gamma[2:nalts+1];
 	vector[nalts] alpha_phi_j = alpha_phi[2:nalts+1];
-	int order_MU[nalts] = sort_indices_desc(MU_j);	// find ranking of non-numeraire alts by MUzero
+	array[nalts] int order_MU = sort_indices_desc(MU_j);	// find ranking of non-numeraire alts by MUzero
 
 	parm_matrix = append_col(append_row(MUzero[1], MU_j[order_MU]),
 	append_col(append_row(price[1], price_j[order_MU]),
@@ -127,7 +127,7 @@ vector MarshallianDemand(real income, vector price, vector MUzero, vector phi, v
 	int M = 1; // Indicator of which ordered alternatives (<=M) are being considered
 	int exit = 0;
 	real E;
-	int order_x[nalts+1] = CalcAltOrder(MUzero, nalts);
+	array[nalts+1] int order_x = CalcAltOrder(MUzero, nalts);
 	vector[nalts+1] X = rep_vector(0, nalts+1);
 	vector[nalts+1] d = append_row(0, rep_vector(1, nalts));
 
@@ -214,7 +214,7 @@ vector MarshallianDemand(real income, vector price, vector MUzero, vector phi, v
 
 					lambda = (lambda_l + lambda_u) / 2;
 
-					if (fabs((E - income) / (E + income) * 0.5) < tol_e) break;
+					if (abs((E - income) / (E + income) * 0.5) < tol_e) break;
 				}
 				// Compute demands (using eq. 12 in Pinjari and Bhat)
 				for (m in 1:M)
@@ -308,7 +308,7 @@ vector HicksianDemand(real util, vector price,
 	int exit = 0;
 	real lambda1;
 	real util_new;
-	int order_x[nalts+1] = CalcAltOrder(MUzero, nalts);
+	array[nalts+1] int order_x = CalcAltOrder(MUzero, nalts);
 	vector[nalts+1] X = rep_vector(0, nalts+1); // vector to hold zero demands
 	vector[nalts+1] d = append_row(0, rep_vector(1, nalts));
 
@@ -423,7 +423,7 @@ vector HicksianDemand(real util, vector price,
 
 					lambda1 = (lambda_l + lambda_u) / 2;
 
-					if (fabs((lambda_l - lambda_u) / (lambda_l + lambda_u) * 0.5) < tol_l) break;
+					if (abs((lambda_l - lambda_u) / (lambda_l + lambda_u) * 0.5) < tol_l) break;
 				}
 
 			// Compute demands (using eq. 12 in Pinjari and Bhat)
@@ -457,7 +457,7 @@ return(hdemand);
  * @return Matrix of nsims x npols wtp
  */
 matrix CalcWTP_rng(real income, vector quant_j, vector price,
-						vector[] price_p_policy, matrix[] psi_p_sims, matrix[] phi_p_sims,
+						array[] vector price_p_policy, array[] matrix psi_p_sims, array[] matrix phi_p_sims,
 						matrix psi_sims, matrix phi_sims, matrix gamma_sims, matrix alpha_sims, vector scale_sims,
 						int nerrs, int cond_error, int draw_mlhs,
 						int algo_gen, int model_num, int price_change_only, real tol, int max_loop){
@@ -475,7 +475,7 @@ matrix CalcWTP_rng(real income, vector quant_j, vector price,
 		vector[nalts + 1] gamma = append_row(1, gamma_sims[sim]');
 		vector[nalts + 1] alpha = alpha_sims[sim]';
 		real scale = scale_sims[sim];
-		vector[nalts + 1] error[nerrs];
+		array[nerrs] vector[nalts + 1] error;
 		vector[npols] wtp_policy;
 		vector[nerrs] util;
 
@@ -539,8 +539,8 @@ matrix CalcWTP_rng(real income, vector quant_j, vector price,
 return(wtp);
 }
 
-matrix[] CalcMarshallianDemand_rng(real income, vector quant_j, vector price,
-						vector[] price_p_policy, matrix[] psi_p_sims, matrix[] phi_p_sims,
+array[] matrix CalcMarshallianDemand_rng(real income, vector quant_j, vector price,
+						array[] vector price_p_policy, array[] matrix psi_p_sims, array[] matrix phi_p_sims,
 						matrix psi_sims, matrix phi_sims, matrix gamma_sims, matrix alpha_sims, vector scale_sims,
 						int nerrs, int cond_error, int draw_mlhs,
 						int algo_gen, int model_num, int price_change_only, real tol, int max_loop){
@@ -548,7 +548,7 @@ matrix[] CalcMarshallianDemand_rng(real income, vector quant_j, vector price,
 	int nalts = num_elements(quant_j);
 	int nsims = num_elements(scale_sims);
 	int npols = size(price_p_policy);
-	matrix[npols, nalts+1] mdemand_out[nsims];
+	array[nsims] matrix[npols, nalts+1] mdemand_out;
 	real quant_num = income - quant_j' * price[2:nalts+1];
 
 	for (sim in 1:nsims){
@@ -558,7 +558,7 @@ matrix[] CalcMarshallianDemand_rng(real income, vector quant_j, vector price,
 		vector[nalts + 1] gamma = append_row(1, gamma_sims[sim]');
 		vector[nalts + 1] alpha = alpha_sims[sim]';
 		real scale = scale_sims[sim];
-		vector[nalts + 1] error[nerrs];
+		array[nerrs] vector[nalts + 1] error;
 		matrix[npols, nalts + 1] mdemand_pols;
 		vector[nerrs] util;
 
@@ -630,7 +630,7 @@ vector CalcmdemandOne_rng(real income, vector price,
 	vector[nalts + 1] mdemand = rep_vector(0, nalts + 1);
 	vector[nalts + 1] gamma = append_row(1, gamma_j);
 	vector[nalts + 1] phi;
-	vector[nalts + 1] error[nerrs];
+	array[nerrs] vector[nalts + 1] error;
 
 	if (model_num < 5)
 		phi = rep_vector(1, nalts + 1);

--- a/inst/stan/mdcev.stan
+++ b/inst/stan/mdcev.stan
@@ -13,7 +13,7 @@ data {
 
 // additional LC data that can be set to 0 if not used
 	int L; // number of predictors in membership equation
-//	vector[L] data_class[I];   // predictors for component membership
+//	array[I] vector[L] data_class;   // predictors for component membership
 	matrix[I, L] data_class;   // predictors for component membership
 	int<lower=0, upper=1> single_scale; // indicator to estimate one scale for lc
 	real prior_delta_sd;
@@ -27,10 +27,10 @@ if (single_scale == 0 && fixed_scale1 == 0)
 }
 
 parameters {
-	vector[NPsi] psi[K];
-	vector[NPhi] phi[K];
-	vector<lower=0 >[Gamma] gamma[K];
-	vector<lower=0, upper=1>[A] alpha[K];
+	array[K] vector[NPsi] psi;
+	array[K] vector[NPhi] phi;
+	array[K] vector<lower=0 >[Gamma] gamma;
+	array[K] vector<lower=0, upper=1>[A] alpha;
 	vector<lower=0>[S] scale;
   	matrix[K - 1, L] delta;  // mixture regression coeffs
 }
@@ -38,7 +38,7 @@ parameters {
 transformed parameters {
 	vector[I] log_like;
 	{
-	vector[I] log_like_util[K];
+	array[K] vector[I] log_like_util;
 	for (k in 1:K){
 		matrix[I, J] gamma_full = gamma_ll(gamma[k], I, J, Gamma);
 		real scale_full;

--- a/inst/stan/mdcev_rp.stan
+++ b/inst/stan/mdcev_rp.stan
@@ -7,10 +7,10 @@ functions {
 data {
 #include /common/mdcev_data.stan
   int<lower=0, upper=1> corr;
-  int task[I]; // index for tasks
-  int task_individual[I]; // index for individual
-  int start[I]; // the starting observation for each task
-  int end[I]; // the ending observation for each task
+  array[I] int task; // index for tasks
+  array[I] int task_individual; // index for individual
+  array[I] int start; // the starting observation for each task
+  array[I] int end; // the ending observation for each task
   real<lower=1> lkj_shape; // shape parameter for LKJ prior
 //  vector[NPsi] psi_ndx;
   int<lower=0, upper=1>  gamma_nonrandom;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `fabs` replaced by `abs`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
