### PR TITLE
Exclude generated src/SimulationFunctions.cpp from the built tarball

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^benchmark_apollo\.R$
 ^vignettes/apollo-benchmark\.html$
 ^vignettes/apollo-benchmark_files$
+^src/SimulationFunctions\.cpp$


### PR DESCRIPTION
## Problem

PR #11 removed the pre-generated `src/SimulationFunctions.cpp` from version control so it is regenerated by rstantools at install time, and added it to `.gitignore`.

**`.gitignore` does not apply to `R CMD build`.** Only `.Rbuildignore` does.

`R CMD build` copies the package to a temp directory and installs it there to build vignettes. That install runs `configure`/`configure.win` → `rstantools::rstan_config()`, which generates `src/SimulationFunctions.cpp` in the copy. `R CMD build` then tars it up.

Verified on the 1.3.3 candidate tarball built before this fix:

```
-rw-rw-rw- plloy/0  167425  2026-07-20 09:34  rmdcev/src/SimulationFunctions.cpp
```

167 KB, generated during the build — despite being absent from git and from `src/`.

This defeats the purpose of #11: CRAN would compile the shipped, platform-specific copy instead of regenerating it against the rstan/StanHeaders present at install time, which is exactly the coupling that breaks under rstan 2.39.0.

## Fix

One line in `.Rbuildignore`:

```
^src/SimulationFunctions\.cpp$
```

`inst/stan/SimulationFunctions.stan` and `configure`/`configure.win` are still shipped, so the file is regenerated at install as intended.

## Verification

`R CMD build` + `R CMD check --as-cran` with R 4.6.1 on Windows 11, on the rebuilt tarball:

- `src/SimulationFunctions.cpp` no longer present in the tarball
- `inst/stan/SimulationFunctions.stan`, `configure`, `configure.win` still present
- **`checking whether package 'rmdcev' can be installed ... [256s] OK`** — confirms the file is regenerated at install with no shipped copy
- `checking tests ... [60s] OK`
- `checking examples with --run-donttest ... OK`
- 0 errors, 0 warnings

Remaining NOTEs are local-environment artifacts, not package defects: pandoc not installed; `-Wa,-mbig-obj` injected by `StanHeaders:::CxxFlags()` on Windows; CRLF on the *regenerated* `SimulationFunctions.cpp` (Windows-only, LF on CRAN's Linux builders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
